### PR TITLE
Fix player data not being copied on respawn

### DIFF
--- a/src/main/java/folk/sisby/surveyor/PlayerSummary.java
+++ b/src/main/java/folk/sisby/surveyor/PlayerSummary.java
@@ -45,7 +45,6 @@ public interface PlayerSummary {
 	}
 
 	SurveyorExploration exploration();
-	void copyExploration(PlayerSummary oldSummary);
 
 	String username();
 
@@ -101,10 +100,6 @@ public interface PlayerSummary {
 			return 0;
 		}
 
-		@Override
-		public void copyExploration(PlayerSummary oldSummary) {
-		}
-
 		public record OfflinePlayerExploration(Set<UUID> sharedPlayers, Map<RegistryKey<World>, Map<ChunkPos, BitSet>> terrain, Map<RegistryKey<World>, Map<RegistryKey<Structure>, LongSet>> structures, boolean personal) implements SurveyorExploration {
 			public static OfflinePlayerExploration ofMerged(Set<SurveyorExploration> explorations) {
 				Set<UUID> sharedPlayers = new HashSet<>();
@@ -137,10 +132,6 @@ public interface PlayerSummary {
 		@Override
 		public SurveyorExploration exploration() {
 			return null;
-		}
-
-		@Override
-		public void copyExploration(PlayerSummary oldSummary) {
 		}
 
 		@Override
@@ -188,13 +179,12 @@ public interface PlayerSummary {
 		}
 
 		@Override
-		public void copyExploration(PlayerSummary oldSummary) {
-			exploration.copyFrom(((ServerPlayerEntitySummary) oldSummary).exploration);
-		}
-
-		@Override
 		public int viewDistance() {
 			return ((ServerPlayerEntity) this.player).getViewDistance();
+		}
+
+		public void copyExploration(ServerPlayerEntitySummary oldSummary) {
+			exploration.copyFrom(oldSummary.exploration);
 		}
 
 		public void read(NbtCompound nbt) {

--- a/src/main/java/folk/sisby/surveyor/PlayerSummary.java
+++ b/src/main/java/folk/sisby/surveyor/PlayerSummary.java
@@ -45,6 +45,7 @@ public interface PlayerSummary {
 	}
 
 	SurveyorExploration exploration();
+	void copyExploration(PlayerSummary oldSummary);
 
 	String username();
 
@@ -100,6 +101,10 @@ public interface PlayerSummary {
 			return 0;
 		}
 
+		@Override
+		public void copyExploration(PlayerSummary oldSummary) {
+		}
+
 		public record OfflinePlayerExploration(Set<UUID> sharedPlayers, Map<RegistryKey<World>, Map<ChunkPos, BitSet>> terrain, Map<RegistryKey<World>, Map<RegistryKey<Structure>, LongSet>> structures, boolean personal) implements SurveyorExploration {
 			public static OfflinePlayerExploration ofMerged(Set<SurveyorExploration> explorations) {
 				Set<UUID> sharedPlayers = new HashSet<>();
@@ -132,6 +137,10 @@ public interface PlayerSummary {
 		@Override
 		public SurveyorExploration exploration() {
 			return null;
+		}
+
+		@Override
+		public void copyExploration(PlayerSummary oldSummary) {
 		}
 
 		@Override
@@ -176,6 +185,11 @@ public interface PlayerSummary {
 		@Override
 		public SurveyorExploration exploration() {
 			return exploration;
+		}
+
+		@Override
+		public void copyExploration(PlayerSummary oldSummary) {
+			exploration.copyFrom(((ServerPlayerEntitySummary) oldSummary).exploration);
 		}
 
 		@Override

--- a/src/main/java/folk/sisby/surveyor/SurveyorExploration.java
+++ b/src/main/java/folk/sisby/surveyor/SurveyorExploration.java
@@ -56,6 +56,11 @@ public interface SurveyorExploration {
 
 	Set<UUID> sharedPlayers();
 
+	default void copyFrom(SurveyorExploration oldExploration) {
+		terrain().putAll(oldExploration.terrain());
+		structures().putAll(oldExploration.structures());
+	}
+
 	boolean personal();
 
 	default boolean exploredChunk(RegistryKey<World> worldKey, ChunkPos pos) {

--- a/src/main/java/folk/sisby/surveyor/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/folk/sisby/surveyor/mixin/MixinServerPlayerEntity.java
@@ -56,6 +56,11 @@ public class MixinServerPlayerEntity implements SurveyorPlayer {
 		);
 	}
 
+	@Inject(method = "copyFrom", at = @At("TAIL"))
+	public void copyFrom(MixinServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
+		surveyor$summary.copyExploration(oldPlayer.surveyor$summary);
+	}
+
 	@Override
 	public PlayerSummary surveyor$getSummary() {
 		return surveyor$summary;


### PR DESCRIPTION
When a player respawns, a new `ServerPlayerEntity` object is created to replace the old one. Instead of reading nbt data from the save, the game copies the data from the old object. `MixinServerPlayerEntity` does not have an inject for that, which means the new `ServerPlayerEntitySummary` remains empty and the player loses all their exploration data. I believe this is the cause of https://github.com/sisby-folk/antique-atlas/issues/170

This is my attempt to fix it. I don't really know java, so I'm not sure if what I did was right, but it seems to work. I haven't tested it in multiplayer.