### PR TITLE
Replace description field with ComponentMap

### DIFF
--- a/src/main/java/folk/sisby/surveyor/SurveyorCommands.java
+++ b/src/main/java/folk/sisby/surveyor/SurveyorCommands.java
@@ -18,6 +18,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DefaultPosArgument;
 import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.component.ComponentMap;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -290,7 +291,7 @@ public class SurveyorCommands {
 			feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("A landmark exists of that type and position!").formatted(Formatting.YELLOW)));
 			return 0;
 		}
-		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : Surveyor.getUuid(player), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? Text.of(name.substring(name.indexOf("\\n") + 2)) : null, null));
+		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : Surveyor.getUuid(player), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), ComponentMap.EMPTY, null));
 		feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("%s added successfully!".formatted(global ? "Landmark" : "Waypoint")).formatted(Formatting.GREEN)));
 		return 1;
 	}

--- a/src/main/java/folk/sisby/surveyor/SurveyorCommands.java
+++ b/src/main/java/folk/sisby/surveyor/SurveyorCommands.java
@@ -18,6 +18,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DefaultPosArgument;
 import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.component.ComponentMap;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -290,7 +291,7 @@ public class SurveyorCommands {
 			feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("A landmark exists of that type and position!").formatted(Formatting.YELLOW)));
 			return 0;
 		}
-		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : Surveyor.getUuid(player), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? Text.of(name.substring(name.indexOf("\\n") + 2)) : null, null));
+		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : Surveyor.getUuid(player), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? ComponentMap.EMPTY : null, null));
 		feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("%s added successfully!".formatted(global ? "Landmark" : "Waypoint")).formatted(Formatting.GREEN)));
 		return 1;
 	}

--- a/src/main/java/folk/sisby/surveyor/client/SurveyorClientCommands.java
+++ b/src/main/java/folk/sisby/surveyor/client/SurveyorClientCommands.java
@@ -25,6 +25,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DefaultPosArgument;
 import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.component.ComponentMap;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
@@ -204,7 +205,7 @@ public class SurveyorClientCommands {
 			feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("A landmark exists of that type and position!").formatted(Formatting.YELLOW)));
 			return 0;
 		}
-		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : SurveyorClient.getClientUuid(), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? Text.of(name.substring(name.indexOf("\\n") + 2)) : null, null));
+		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : SurveyorClient.getClientUuid(), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), ComponentMap.EMPTY, null));
 		feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("%s added successfully!".formatted(global ? "Landmark" : "Waypoint")).formatted(Formatting.GREEN)));
 		return 1;
 	}

--- a/src/main/java/folk/sisby/surveyor/client/SurveyorClientCommands.java
+++ b/src/main/java/folk/sisby/surveyor/client/SurveyorClientCommands.java
@@ -25,6 +25,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DefaultPosArgument;
 import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.component.ComponentMap;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
@@ -204,7 +205,7 @@ public class SurveyorClientCommands {
 			feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("A landmark exists of that type and position!").formatted(Formatting.YELLOW)));
 			return 0;
 		}
-		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : SurveyorClient.getClientUuid(), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? Text.of(name.substring(name.indexOf("\\n") + 2)) : null, null));
+		summary.landmarks().put(world, new SimplePointLandmark(pos, global ? null : SurveyorClient.getClientUuid(), color, Text.of(name.contains("\\n") ? name.substring(0, name.indexOf("\\n")) : name), name.contains("\\n") ? ComponentMap.EMPTY : null, null));
 		feedback.accept(Text.literal("[Surveyor] ").formatted(Formatting.DARK_RED).append(Text.literal("%s added successfully!".formatted(global ? "Landmark" : "Waypoint")).formatted(Formatting.GREEN)));
 		return 1;
 	}

--- a/src/main/java/folk/sisby/surveyor/landmark/SimplePointLandmark.java
+++ b/src/main/java/folk/sisby/surveyor/landmark/SimplePointLandmark.java
@@ -2,6 +2,7 @@ package folk.sisby.surveyor.landmark;
 
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import folk.sisby.surveyor.Surveyor;
+import net.minecraft.component.ComponentMap;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextCodecs;
 import net.minecraft.util.DyeColor;
@@ -12,20 +13,20 @@ import net.minecraft.util.math.BlockPos;
 import java.util.Optional;
 import java.util.UUID;
 
-public record SimplePointLandmark(BlockPos pos, Optional<UUID> optionalOwner, Optional<DyeColor> optionalColor, Optional<Text> optionalName, Optional<Text> optionalDescription, Optional<Identifier> optionalTexture) implements VariableLandmark<SimplePointLandmark> {
+public record SimplePointLandmark(BlockPos pos, Optional<UUID> optionalOwner, Optional<DyeColor> optionalColor, Optional<Text> optionalName, Optional<ComponentMap> optionalComponents, Optional<Identifier> optionalTexture) implements VariableLandmark<SimplePointLandmark> {
 	public static final LandmarkType<SimplePointLandmark> TYPE = new SimpleLandmarkType<>(
 		Identifier.of(Surveyor.ID, "point"),
 		pos -> RecordCodecBuilder.create(instance -> instance.group(
 			Uuids.CODEC.optionalFieldOf("owner").forGetter(VariableLandmark::optionalOwner),
 			DyeColor.CODEC.optionalFieldOf("color").orElse(null).forGetter(VariableLandmark::optionalColor),
 			TextCodecs.CODEC.optionalFieldOf("name").orElse(null).forGetter(VariableLandmark::optionalName),
-			TextCodecs.CODEC.optionalFieldOf("description").orElse(null).forGetter(VariableLandmark::optionalDescription),
+			ComponentMap.CODEC.optionalFieldOf("components").orElse(null).forGetter(VariableLandmark::optionalComponents),
 			Identifier.CODEC.optionalFieldOf("texture").orElse(null).forGetter(VariableLandmark::optionalTexture)
-		).apply(instance, (owner, color, name, description, texture) -> new SimplePointLandmark(pos, owner, color, name, description, texture)))
+		).apply(instance, (owner, color, name, components, texture) -> new SimplePointLandmark(pos, owner, color, name, components, texture)))
 	);
 
-	public SimplePointLandmark(BlockPos pos, UUID owner, DyeColor color, Text name, Text description, Identifier texture) {
-		this(pos, Optional.ofNullable(owner), Optional.ofNullable(color), Optional.ofNullable(name), Optional.ofNullable(description), Optional.ofNullable(texture));
+	public SimplePointLandmark(BlockPos pos, UUID owner, DyeColor color, Text name, ComponentMap components, Identifier texture) {
+		this(pos, Optional.ofNullable(owner), Optional.ofNullable(color), Optional.ofNullable(name), Optional.ofNullable(components), Optional.ofNullable(texture));
 	}
 
 	@Override

--- a/src/main/java/folk/sisby/surveyor/landmark/VariableLandmark.java
+++ b/src/main/java/folk/sisby/surveyor/landmark/VariableLandmark.java
@@ -1,5 +1,6 @@
 package folk.sisby.surveyor.landmark;
 
+import net.minecraft.component.ComponentMap;
 import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
@@ -27,11 +28,11 @@ public interface VariableLandmark<T extends VariableLandmark<T>> extends Landmar
 
 	Optional<Text> optionalName();
 
-	default @Nullable Text description() {
-		return optionalDescription().orElse(null);
+	default @Nullable ComponentMap components() {
+		return optionalComponents().orElse(null);
 	}
 
-	Optional<Text> optionalDescription();
+	Optional<ComponentMap> optionalComponents();
 
 	default @Nullable Identifier texture() {
 		return optionalTexture().orElse(null);


### PR DESCRIPTION
See issue #68.
Implementation details are free to change here. I'm just throwing this out here while I'm testing it. Might add a ComponentMap for chunk summaries as well later, as mentioned in the issue. The chunk summary use-case I've found is for AA4 Atlas - I want to add a way to track which chunks were explored with the atlas item present, while syncing it alongside the main chunk summary packet for share compatibility.

I don't know a thing about NBT, hence no 1.20 backport yet...