### PR TITLE
Fix for IndexOutOfBoundsException

### DIFF
--- a/src/main/java/folk/sisby/surveyor/util/ListUtil.java
+++ b/src/main/java/folk/sisby/surveyor/util/ListUtil.java
@@ -8,7 +8,9 @@ public class ListUtil {
 
 	public static <T> List<T> splitSet(List<T> list, BitSet set, BitSet oldSet) {
 		List<T> outList = new ArrayList<>();
-		for (int i = 0; i < oldSet.stream().toArray().length; i++) {
+		
+		int length = Math.min(Math.min(oldSet.length(), set.length()), list.size());
+		for (int i = 0; i < length; i++) {
 			if (set.get(i)) outList.add(list.get(i));
 		}
 		return outList;


### PR DESCRIPTION
Fix to compare list, set, and oldSet's size to avoid an IndexOutOfBoundsException that occurs when they are not the same.