### PR TITLE
fix BitSetUtil.half method to use cardinality instead of size

### DIFF
--- a/src/main/java/folk/sisby/surveyor/util/BitSetUtil.java
+++ b/src/main/java/folk/sisby/surveyor/util/BitSetUtil.java
@@ -9,7 +9,7 @@ public class BitSetUtil {
 		BitSet firstHalf = BitSet.valueOf(original.toLongArray());
 		BitSet secondHalf = BitSet.valueOf(original.toLongArray());
 		int fromIndex = 0;
-		for (int i = 0; i < original.size() / 2; i++) {
+		for (int i = 0; i < original.cardinality() / 2; i++) {
 			fromIndex = firstHalf.nextSetBit(fromIndex);
 			firstHalf.clear(fromIndex);
 		}


### PR DESCRIPTION
i think this should resolve #127 

at the very least, the function i dont think does what its supposed to, so this should be fixed.

i'll try running the patched jar on our server for a bit and see if it keeps happening