### PR TITLE
Add Launchpad metadata

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -37,7 +37,7 @@ ordering = "NONE"
 side = "BOTH"
 
 [[dependencies."${ modId }"]]
-modId = "fabric_api"
+modId = "forgified_fabric_api"
 type = "required"
 versionRange = "[${fapi},)"
 ordering = "NONE"

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -13,10 +13,10 @@ displayURL = "${homepage}"
 logoFile = "assets/${modId}/icon.png"
 
 [properties]
-"connector:placeholder" = true
+"launchpad:placeholder" = true
 
 [[dependencies."${ modId }"]]
-modId = "connector"
+modId = "launchpad"
 type = "required"
 versionRange = "*"
 ordering = "NONE"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,5 +33,17 @@
 		"client": [
 			"folk.sisby.surveyor.client.SurveyorClient"
 		]
+	},
+	"custom": {
+		"launchpad:compatible": true,
+		"launchpad:overrides": {
+			"depends": {
+				"minecraft": ">=${mc}",
+				"fabric_api_base": "*",
+				"fabric_command_api_v2": "*",
+				"fabric_networking_api_v1": "*",
+				"fabric_lifecycle_events_v1": "*"
+			}
+		}
 	}
 }


### PR DESCRIPTION
[Launchpad](https://modrinth.com/mod/launchpad) is a new tool from the developers of Sinytra Connector and the Forgified Fabric API, used to allow mods that do not require modification to load on NeoForge while reusing Fabric metadata. Forgified Fabric API is still required, but Launchpad can be used in place of Connector on 26.1 since the game is now unobfuscated and Fabric mods need far less work to launch on NeoForge.

I left the dependency on Forgified Fabric API on NeoForge, but the Launchpad metadata only requires the modules of FFAPI that are actually needed, to make developing mods that depend on Surveyor easier and not require the entirety of FFAPI (which currently is incompatible with Sodium).